### PR TITLE
Debian OS bug fixes

### DIFF
--- a/lib/fluent/plugin/logging_setup.rb
+++ b/lib/fluent/plugin/logging_setup.rb
@@ -225,7 +225,7 @@ module Fluent
         elsif OS.ubuntu?
           @ca_file = @ca_file == PUBLIC_DEFAULT_LINUX_CA_PATH ? PUBLIC_DEFAULT_UBUNTU_CA_PATH : @ca_file
         elsif OS.debian?
-          @ca_file = @ca_file == PUBLIC_DEFAULT_LINUX_CA_PATH ? PUBLIC_DEFAULT_DEBIAN_CA_PATH : @ca_file
+          @ca_file = (@ca_file.nil || @ca_file == PUBLIC_DEFAULT_LINUX_CA_PATH) ? PUBLIC_DEFAULT_DEBIAN_CA_PATH : @ca_file
         else
           @ca_file = @region == 'r1' && @ca_file == PUBLIC_DEFAULT_LINUX_CA_PATH ? R1_CA_PATH : @ca_file
         end

--- a/lib/fluent/plugin/logging_setup.rb
+++ b/lib/fluent/plugin/logging_setup.rb
@@ -27,6 +27,7 @@ module Fluent
       PUBLIC_DEFAULT_LINUX_CA_PATH = '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem'
       PUBLIC_DEFAULT_WINDOWS_CA_PATH = 'C:\\oracle_unified_agent\\unified-monitoring-agent\\embedded\\ssl\\certs\\cacert.pem'
       PUBLIC_DEFAULT_UBUNTU_CA_PATH = '/etc/ssl/certs/ca-certificates.crt'
+      PUBLIC_DEFAULT_DEBIAN_CA_PATH = PUBLIC_DEFAULT_UBUNTU_CA_PATH
 
       def logger
         @log ||= OS.windows? ? Logger.new(WINDOWS_UPLOADER_OUTPUT_LOG) : Logger.new($stdout)
@@ -223,6 +224,8 @@ module Fluent
           @ca_file = @ca_file == PUBLIC_DEFAULT_LINUX_CA_PATH ? PUBLIC_DEFAULT_WINDOWS_CA_PATH : @ca_file
         elsif OS.ubuntu?
           @ca_file = @ca_file == PUBLIC_DEFAULT_LINUX_CA_PATH ? PUBLIC_DEFAULT_UBUNTU_CA_PATH : @ca_file
+        elsif OS.debian?
+          @ca_file = @ca_file == PUBLIC_DEFAULT_LINUX_CA_PATH ? PUBLIC_DEFAULT_DEBIAN_CA_PATH : @ca_file
         else
           @ca_file = @region == 'r1' && @ca_file == PUBLIC_DEFAULT_LINUX_CA_PATH ? R1_CA_PATH : @ca_file
         end

--- a/lib/fluent/plugin/logging_setup.rb
+++ b/lib/fluent/plugin/logging_setup.rb
@@ -220,12 +220,13 @@ module Fluent
       # Since r1 overlay has a different default make sure to update this
       #
       def set_default_ca_file
+        @ca_file = PUBLIC_DEFAULT_LINUX_CA_PATH if @ca_file.nil?
         if OS.windows?
           @ca_file = @ca_file == PUBLIC_DEFAULT_LINUX_CA_PATH ? PUBLIC_DEFAULT_WINDOWS_CA_PATH : @ca_file
         elsif OS.ubuntu?
           @ca_file = @ca_file == PUBLIC_DEFAULT_LINUX_CA_PATH ? PUBLIC_DEFAULT_UBUNTU_CA_PATH : @ca_file
         elsif OS.debian?
-          @ca_file = (@ca_file.nil || @ca_file == PUBLIC_DEFAULT_LINUX_CA_PATH) ? PUBLIC_DEFAULT_DEBIAN_CA_PATH : @ca_file
+          @ca_file = @ca_file == PUBLIC_DEFAULT_LINUX_CA_PATH ? PUBLIC_DEFAULT_DEBIAN_CA_PATH : @ca_file
         else
           @ca_file = @region == 'r1' && @ca_file == PUBLIC_DEFAULT_LINUX_CA_PATH ? R1_CA_PATH : @ca_file
         end

--- a/lib/fluent/plugin/os.rb
+++ b/lib/fluent/plugin/os.rb
@@ -27,6 +27,10 @@ module OS
     linux? and os_name_ubuntu?
   end
 
+  def self.debian?
+    linux? and os_name_debian?
+  end
+
   def self.os_name_ubuntu?
     os_name = 'not_found'
     file_name = '/etc/os-release'
@@ -40,6 +44,24 @@ module OS
       logger.info('Unknown linux distribution detected')
     end
     os_name == 'ubuntu' ? true : false
+  rescue StandardError => e
+    log.error "Unable to detect ubuntu platform due to: #{e.message}"
+    false
+  end
+
+  def self.os_name_debian?
+    os_name = 'not_found'
+    file_name = '/etc/os-release'
+    if File.exists?(file_name)
+      File.foreach(file_name).each do |line|
+        if line.start_with?('ID=')
+          os_name = line.split('=')[1].strip
+        end
+      end
+    else
+      logger.info('Unknown linux distribution detected')
+    end
+    os_name == 'debian' ? true : false
   rescue StandardError => e
     log.error "Unable to detect ubuntu platform due to: #{e.message}"
     false

--- a/test/plugin/test_logging_setup.rb
+++ b/test/plugin/test_logging_setup.rb
@@ -250,7 +250,11 @@ class PublicloggingSetupTest < Test::Unit::TestCase
     set_default_ca_file
     assert_equal @ca_file, 'something/unexpect'
 
-    OS.expects(:ubuntu?).returns(false) && OS.expects(:windows?).returns(false)
+    # OS.expects(:ubuntu?).returns(false) && OS.expects(:windows?).returns(false)
+    OS.expects(:ubuntu?).returns(false)
+    OS.expects(:windows?).returns(false)
+    OS.expects(:debian?).returns(false)
+
     @ca_file = PUBLIC_DEFAULT_LINUX_CA_PATH
     @region = 'r1'
     set_default_ca_file
@@ -268,6 +272,14 @@ class PublicloggingSetupTest < Test::Unit::TestCase
     @region = 'us-phoenix-1'
     set_default_ca_file
     assert_equal @ca_file, 'something/unexpect'
+
+    OS.expects(:windows?).returns(false)
+    OS.expects(:debian?).returns(true)
+    OS.expects(:ubuntu?).returns(false)
+    @ca_file = PUBLIC_DEFAULT_LINUX_CA_PATH
+    @region = 'us-phoenix-1'
+    set_default_ca_file
+    assert_equal @ca_file, PUBLIC_DEFAULT_DEBIAN_CA_PATH
   end
 
   test 'get_signer_type' do


### PR DESCRIPTION
Issue #2 

#### Published version
https://rubygems.org/gems/fluent-plugin-oci-logging/versions/1.0.5 

#### Summary:
- add debian support
- bugfix

#### Details
A bug in the repository which causes a runtime error on initialization under Debian. The default directory for CA certificates is not applicable for Debian which causes failure upon configuration.
The path to CA certs has been updated, along with relevant changes in the test plugin.





Signed-off-by: Priyanka <propriyankav@gmail.com>