### PR TITLE
Fix deprecation in os.rb

### DIFF
--- a/lib/fluent/plugin/os.rb
+++ b/lib/fluent/plugin/os.rb
@@ -34,7 +34,7 @@ module OS
   def self.os_name_ubuntu?
     os_name = 'not_found'
     file_name = '/etc/os-release'
-    if File.exists?(file_name)
+    if File.exist?(file_name)
       IO.foreach(file_name).each do |line|
         if line.start_with?('ID=')
           os_name = line.split('=')[1].strip
@@ -52,7 +52,7 @@ module OS
   def self.os_name_debian?
     os_name = 'not_found'
     file_name = '/etc/os-release'
-    if File.exists?(file_name)
+    if File.exist?(file_name)
       File.foreach(file_name).each do |line|
         if line.start_with?('ID=')
           os_name = line.split('=')[1].strip


### PR DESCRIPTION
File.exists? have been removed from ruby since 3.2.0. The correct method name is File.exist?